### PR TITLE
Oro 6.0.x compatibility added

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "exclude-from-classmap": ["/Tests/"]
     },
     "require": {
-        "php": "~8.2.0",
-        "oro/commerce": "5.1.*"
+        "php": "~8.3.0",
+        "oro/commerce": "6.0.*"
     },
     "repositories": {
         "oro": {
@@ -33,7 +33,7 @@
     "require-dev": {
         "phpmd/phpmd": "^2.13",
         "phpro/grumphp": "^1.15",
-        "phpspec/phpspec": "^6.1",
+        "phpspec/phpspec": "^7.5",
         "phpstan/phpstan-symfony": "^1.2",
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "friendsofphp/php-cs-fixer": "^3.4"

--- a/src/Synolia/Bundle/FavoriteBundle/Controller/Frontend/FavoriteAjaxController.php
+++ b/src/Synolia/Bundle/FavoriteBundle/Controller/Frontend/FavoriteAjaxController.php
@@ -9,7 +9,7 @@ use Oro\Bundle\ProductBundle\Entity\Product;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Synolia\Bundle\FavoriteBundle\Handler\FavoriteAjaxHandler;
 
@@ -22,16 +22,11 @@ class FavoriteAjaxController extends AbstractController
     }
 
     /**
-     * @Route(
-     *     "/create/{id}",
-     *     requirements={"id"="\d+"},
-     *     name="synolia_favorite_button_ajax_update"
-     *     )
      *
      * @param Product $product
-     *
      * @return JsonResponse
      */
+    #[\Symfony\Component\Routing\Attribute\Route(path: '/create/{id}', requirements: ['id' => '\d+'], name: 'synolia_favorite_button_ajax_update')]
     public function create(Product $product): JsonResponse
     {
         $result = $this->favoriteAjaxHandler->create($product);

--- a/src/Synolia/Bundle/FavoriteBundle/Controller/Frontend/FavoriteController.php
+++ b/src/Synolia/Bundle/FavoriteBundle/Controller/Frontend/FavoriteController.php
@@ -4,17 +4,15 @@ declare(strict_types=1);
 
 namespace Synolia\Bundle\FavoriteBundle\Controller\Frontend;
 
-use Oro\Bundle\LayoutBundle\Annotation\Layout;
+use Oro\Bundle\LayoutBundle\Attribute\Layout;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Synolia\Bundle\FavoriteBundle\Entity\Favorite;
 
 class FavoriteController extends AbstractController
 {
-    /**
-     * @Route("/", name="synolia_favorite_view")
-     * @Layout(vars={"entity_class"})
-     */
+    #[\Symfony\Component\Routing\Attribute\Route(path: '/', name: 'synolia_favorite_view')]
+    #[Layout(vars: ['entity_class'])]
     public function indexAction(): array
     {
         $entityClass = Favorite::class;

--- a/src/Synolia/Bundle/FavoriteBundle/Entity/Favorite.php
+++ b/src/Synolia/Bundle/FavoriteBundle/Entity/Favorite.php
@@ -9,7 +9,7 @@ use Oro\Bundle\CustomerBundle\Entity\Ownership\FrontendCustomerUserAwareTrait;
 use Oro\Bundle\EntityBundle\EntityProperty\CreatedAtAwareTrait;
 use Oro\Bundle\EntityBundle\EntityProperty\DatesAwareInterface;
 use Oro\Bundle\EntityBundle\EntityProperty\DatesAwareTrait;
-use Oro\Bundle\EntityConfigBundle\Metadata\Annotation\Config;
+use Oro\Bundle\EntityConfigBundle\Metadata\Attribute\Config;
 use Oro\Bundle\EntityExtendBundle\Entity\ExtendEntityInterface;
 use Oro\Bundle\EntityExtendBundle\Entity\ExtendEntityTrait;
 use Oro\Bundle\OrganizationBundle\Entity\OrganizationAwareInterface;
@@ -17,27 +17,11 @@ use Oro\Bundle\OrganizationBundle\Entity\Ownership\OrganizationAwareTrait;
 use Oro\Bundle\ProductBundle\Entity\Product;
 use Synolia\Bundle\FavoriteBundle\Model\ExtendFavorite;
 
-/**
- * @ORM\Entity(repositoryClass="Synolia\Bundle\FavoriteBundle\Entity\Repository\FavoriteRepository")
- * @ORM\Table(name="sy_favorite")
 
- * @Config(
- *      defaultValues={
- *          "ownership"={
- *              "organization_field_name"="organization",
- *              "organization_column_name"="organization_id",
- *              "frontend_owner_type"="FRONTEND_CUSTOMER",
- *              "frontend_owner_field_name"="customerUser",
- *              "frontend_owner_column_name"="customer_user_id",
- *          },
- *          "security"={
- *              "type"="ACL",
- *              "group_name"="commerce"
- *          },
- *      }
- * )
- * @ORM\HasLifecycleCallbacks
- */
+#[ORM\Entity(repositoryClass: \Synolia\Bundle\FavoriteBundle\Entity\Repository\FavoriteRepository::class)]
+#[Config(defaultValues: ['ownership' => ['organization_field_name' => 'organization', 'organization_column_name' => 'organization_id', 'frontend_owner_type' => 'FRONTEND_CUSTOMER', 'frontend_owner_field_name' => 'customerUser', 'frontend_owner_column_name' => 'customer_user_id']], security: ['type' => 'ACL', 'group_name' => 'commerce'])]
+#[ORM\HasLifecycleCallbacks]
+#[ORM\Table(name: 'sy_favorite')]
 class Favorite implements ExtendEntityInterface, OrganizationAwareInterface, DatesAwareInterface
 {
     use CreatedAtAwareTrait;
@@ -48,19 +32,17 @@ class Favorite implements ExtendEntityInterface, OrganizationAwareInterface, Dat
 
     /**
      * @var integer
-     *
-     * @ORM\Id
-     * @ORM\Column(name="id", type="integer")
-     * @ORM\GeneratedValue(strategy="AUTO")
      */
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
     private $id;
 
     /**
      * @var Product
-     *
-     * @ORM\ManyToOne(targetEntity="Oro\Bundle\ProductBundle\Entity\Product")
-     * @ORM\JoinColumn(name="product_id", referencedColumnName="id", onDelete="CASCADE")
      */
+    #[ORM\ManyToOne(targetEntity: \Oro\Bundle\ProductBundle\Entity\Product::class)]
+    #[ORM\JoinColumn(name: 'product_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     protected $product;
 
 

--- a/src/Synolia/Bundle/FavoriteBundle/Twig/FavoriteExtension.php
+++ b/src/Synolia/Bundle/FavoriteBundle/Twig/FavoriteExtension.php
@@ -32,7 +32,7 @@ class FavoriteExtension extends AbstractExtension
         return [
             new TwigFunction(
                 'is_favorite_product',
-                [$this, 'isFavoriteProduct']
+                $this->isFavoriteProduct(...)
             )
         ];
     }


### PR DESCRIPTION
This PR can be used as a starting point for the extension upgrade.
Most of the changes were done automatically with the upgrade-toolkit tool.

Here is a short list of done changes:
- Updated requirements to oro/commerce 6.0.*
- oro/upgrade-toolkit automatic migrations applied

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?   | yes/no
