### PR TITLE
fix: Remove dump

### DIFF
--- a/src/Synolia/Bundle/FavoriteBundle/Handler/FavoriteButtonAjaxHandler.php
+++ b/src/Synolia/Bundle/FavoriteBundle/Handler/FavoriteButtonAjaxHandler.php
@@ -59,7 +59,6 @@ class FavoriteButtonAjaxHandler
             ->setOrganization($user->getOrganization());
 
         $this->entityManager->persist($favorite);
-        dump($favorite);
         $this->entityManager->flush();
 
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?   | no
| Fixed issue | #... <!-- #-prefixed issue number(s), if any -->

When the button is pressed, it doesn't change color because the response is a dump instead of the JSON expected by the JavaScript."