### PR TITLE
Non authenticated favorites

### DIFF
--- a/src/Synolia/Bundle/FavoriteBundle/EventListener/FrontendProductFavoriteDatagridListener.php
+++ b/src/Synolia/Bundle/FavoriteBundle/EventListener/FrontendProductFavoriteDatagridListener.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Synolia\Bundle\FavoriteBundle\EventListener;
 
 use Doctrine\ORM\EntityManager;
+use Oro\Bundle\CustomerBundle\Entity\CustomerUser;
 use Oro\Bundle\DataGridBundle\Datasource\ResultRecord;
 use Oro\Bundle\DataGridBundle\Event\BuildBefore;
 use Oro\Bundle\DataGridBundle\Extension\Formatter\Property\PropertyInterface;
+use Oro\Bundle\OrganizationBundle\Entity\Organization;
 use Oro\Bundle\SearchBundle\Datagrid\Event\SearchResultAfter;
+use Oro\Bundle\SecurityBundle\Authentication\TokenAccessor;
 use Oro\Bundle\SecurityBundle\ORM\Walker\AclHelper;
-use Symfony\Bundle\SecurityBundle\Security;
 use Synolia\Bundle\FavoriteBundle\Entity\Favorite;
 use Synolia\Bundle\FavoriteBundle\Entity\Repository\FavoriteRepository;
 
@@ -19,7 +21,7 @@ class FrontendProductFavoriteDatagridListener
     public function __construct(
         private readonly EntityManager $entityManager,
         private readonly AclHelper $aclHelper,
-        private readonly Security $security
+        private readonly TokenAccessor $tokenAccessor
     ) {
     }
 
@@ -40,8 +42,11 @@ class FrontendProductFavoriteDatagridListener
 
     public function onResultAfter(SearchResultAfter $event): void
     {
+        $user = $this->tokenAccessor->getUser();
+        $organization = $this->tokenAccessor->getOrganization();
         $records = $event->getRecords();
-        if (0 === \count($records)) {
+
+        if (!$user instanceof CustomerUser || !$organization instanceof Organization || 0 === \count($records)) {
             return;
         }
 

--- a/src/Synolia/Bundle/FavoriteBundle/EventListener/ProductListAddFavoriteEventListener.php
+++ b/src/Synolia/Bundle/FavoriteBundle/EventListener/ProductListAddFavoriteEventListener.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Synolia\Bundle\FavoriteBundle\EventListener;
 
 use Doctrine\ORM\EntityManager;
+use Oro\Bundle\CustomerBundle\Entity\CustomerUser;
+use Oro\Bundle\OrganizationBundle\Entity\Organization;
 use Oro\Bundle\ProductBundle\Event\BuildResultProductListEvent;
+use Oro\Bundle\SecurityBundle\Authentication\TokenAccessor;
 use Oro\Bundle\SecurityBundle\ORM\Walker\AclHelper;
 use Synolia\Bundle\FavoriteBundle\Entity\Favorite;
 use Synolia\Bundle\FavoriteBundle\Entity\Repository\FavoriteRepository;
@@ -14,15 +17,18 @@ class ProductListAddFavoriteEventListener
 {
     public function __construct(
         private readonly EntityManager $entityManager,
-        private readonly AclHelper $aclHelper
+        private readonly AclHelper $aclHelper,
+        private readonly TokenAccessor $tokenAccessor
     ) {
     }
 
     public function onBuildResult(BuildResultProductListEvent $event): void
     {
+        $user = $this->tokenAccessor->getUser();
+        $organization = $this->tokenAccessor->getOrganization();
         $records = $event->getProductData();
 
-        if (0 === \count($records)) {
+        if (!$user instanceof CustomerUser || !$organization instanceof Organization || 0 === \count($records)) {
             return;
         }
 

--- a/src/Synolia/Bundle/FavoriteBundle/Resources/config/event_listeners.yml
+++ b/src/Synolia/Bundle/FavoriteBundle/Resources/config/event_listeners.yml
@@ -3,7 +3,7 @@ services:
         arguments:
             - '@doctrine.orm.entity_manager'
             - '@oro_security.acl_helper'
-            - '@security.helper'
+            - '@oro_security.token_accessor'
         tags:
             - { name: kernel.event_listener, event: oro_datagrid.datagrid.build.before.frontend-product-search-grid, method: onBuildBefore }
             - { name: kernel.event_listener, event: oro_datagrid.search_datasource.result.after.frontend-product-search-grid, method: onResultAfter }
@@ -19,5 +19,6 @@ services:
         arguments:
             - '@doctrine.orm.entity_manager'
             - '@oro_security.acl_helper'
+            - '@oro_security.token_accessor'
         tags:
             - { name: kernel.event_listener, event: oro_product.product_list.build_result, method: onBuildResult, priority: 10 }

--- a/src/Synolia/Bundle/FavoriteBundle/Twig/FavoriteExtension.php
+++ b/src/Synolia/Bundle/FavoriteBundle/Twig/FavoriteExtension.php
@@ -30,7 +30,7 @@ class FavoriteExtension extends AbstractExtension
     public function isFavoriteProduct(Product|array|ProductView $product): bool
     {
         if ($product instanceof ProductView) {
-            return $product->get('favorite');
+            return $product->has('favorite') ? $product->get('favorite') : false;
         }
 
         if (\is_array($product)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?   | no
| Fixed issue | #... <!-- #-prefixed issue number(s), if any -->

Allow the non-authenticated user to see the favorite icon correctly, but restrict the visualization of the selected favorite items